### PR TITLE
Generate merino_client bindings.

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -152,6 +152,15 @@ cp -r "$APP_SERVICES_DIR/components/viaduct/ios/" $OUT_DIR
 "${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/support/error/src/errorsupport.udl"
 
 
+###
+#
+# MerinoClient
+#
+###
+
+# UniFFI bindings.
+"${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/merino_client/src/merino_client.udl"
+
 
 ###################### Swift code generation for Focus ######################
 # Glean metrics.


### PR DESCRIPTION
We only need to change one line to build `merino_client` for iOS! 🎉

[These wonderful instructions](https://mozilla.github.io/application-services/book/howtos/locally-published-components-in-firefox-ios.html) explain how to get the `application-services`, `rust-components-swift`, and `firefox-ios` repos all set up, so that Xcode can build against your local checkouts. I was able to follow them with just a few tweaks.